### PR TITLE
feat: Add Copy Message Button for Assistant Messages

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -51,6 +51,9 @@
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.1.3"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/frontend/src/pages/home/components/AssistantMessage/AssistantMessage.tsx
+++ b/frontend/src/pages/home/components/AssistantMessage/AssistantMessage.tsx
@@ -3,6 +3,7 @@ import { LoadingDots } from '@/components';
 import { SenderType } from '@/types';
 import { MessageContainer } from '../MessageContainer';
 import { useAssistantResponseStream } from './useAssistantResponseStream';
+import { Copy } from 'lucide-react';
 
 interface AssistantMessageProps {
   conversationId: string;
@@ -11,14 +12,31 @@ interface AssistantMessageProps {
 function AssistantMessage({ conversationId }: AssistantMessageProps) {
   const responseText = useAssistantResponseStream(conversationId);
 
+  const handleCopy = () => {
+    if (!responseText) return;
+    navigator.clipboard.writeText(responseText);
+  };
+
+
   return (
-    <MessageContainer senderType={SenderType.ASSISTANT}>
-      {!responseText ? (
-        <LoadingDots />
-      ) : (
-        <ReactMarkdown>{responseText}</ReactMarkdown>
+    <div className="flex flex-col items-start space-y-2"> 
+      <MessageContainer senderType={SenderType.ASSISTANT}>
+        {!responseText ? (
+          <LoadingDots />
+        ) : (
+          <ReactMarkdown>{responseText}</ReactMarkdown>
+        )}
+      </MessageContainer>
+
+      {responseText && (
+        <button
+          onClick={handleCopy}
+          className="flex items-center text-gray-500 hover:text-gray-700 cursor-pointer"
+        >
+          <Copy className="h-5 w-5" />
+        </button>
       )}
-    </MessageContainer>
+    </div>
   );
 }
 

--- a/frontend/src/pages/home/components/AssistantMessage/AssistantMessage.tsx
+++ b/frontend/src/pages/home/components/AssistantMessage/AssistantMessage.tsx
@@ -1,8 +1,9 @@
 import ReactMarkdown from 'react-markdown';
-import { LoadingDots } from '@/components';
+import { LoadingDots, Button} from '@/components';
 import { SenderType } from '@/types';
 import { MessageContainer } from '../MessageContainer';
 import { useAssistantResponseStream } from './useAssistantResponseStream';
+import { useAssistantStreamingContext } from '../../context/AssistantStreamingContext';
 import { Copy } from 'lucide-react';
 
 interface AssistantMessageProps {
@@ -11,6 +12,7 @@ interface AssistantMessageProps {
 
 function AssistantMessage({ conversationId }: AssistantMessageProps) {
   const responseText = useAssistantResponseStream(conversationId);
+  const { isStreaming } = useAssistantStreamingContext();
 
   const handleCopy = () => {
     if (!responseText) return;
@@ -28,13 +30,15 @@ function AssistantMessage({ conversationId }: AssistantMessageProps) {
         )}
       </MessageContainer>
 
-      {responseText && (
-        <button
-          onClick={handleCopy}
-          className="flex items-center text-gray-500 hover:text-gray-700 cursor-pointer"
+      {responseText && !isStreaming && (
+        <Button
+        onClick={handleCopy}
+        variant="ghost"
+        size="icon"
+        className="cursor-pointer"
         >
-          <Copy className="h-5 w-5" />
-        </button>
+        <Copy />
+        </Button>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

This PR adds a copy button below the assistant's message, allowing users to copy the Markdown text within it.

- The copy button is **only visible after the assistant message has finished streaming**.
- Clicking the button **copies the assistant's response in Markdown format** to the clipboard.
- No notification appears after copying, as per the issue requirements.

## Related Issue

Closes #4

## Screenshots 
<img width="625" alt="스크린샷 2025-03-14 오후 1 50 12" src="https://github.com/user-attachments/assets/32cc47b4-ff33-45df-83c1-4b9ba02c941d" />

## Additional Notes

- The copy button is placed **outside** the assistant message container.
- The button is implemented using `lucide-react`'s **Copy** icon (`import { Copy } from 'lucide-react';`).
- The dimensions of the icon are `h-5 w-5`, and it has a `cursor-pointer` style.
- The feature was tested to ensure it meets the acceptance criteria.
